### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -81,6 +81,9 @@ jobs:
       - test
       - code-scan
     if: github.event_name == 'release'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python


### PR DESCRIPTION
Potential fix for [https://github.com/arvato-systems-jacs/gimme-aws-creds/security/code-scanning/4](https://github.com/arvato-systems-jacs/gimme-aws-creds/security/code-scanning/4)

To fix the issue, we will add an explicit `permissions` block to the `deploy` job. This block will define the minimum permissions required for the job to function effectively. Specifically, the `deploy` job only needs `contents: read` to fetch code and `packages: write` to publish the package to PyPI. These permissions adhere to the principle of least privilege and ensure that the job has no unnecessary access rights.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
